### PR TITLE
Improved line coverage of BustServiceProvider from 78% to 92%

### DIFF
--- a/tests/Integration/BustServiceProviderTest.php
+++ b/tests/Integration/BustServiceProviderTest.php
@@ -3,6 +3,7 @@
 namespace Exolnet\Bust\Tests\Integration;
 
 use Exolnet\Bust\Bust;
+use Exolnet\Bust\BustServiceProvider;
 
 class BustServiceProviderTest extends TestCase
 {
@@ -46,5 +47,15 @@ class BustServiceProviderTest extends TestCase
         );
 
         $this->assertEquals($bust, app('bust'));
+    }
+
+    /**
+     * @return void
+     * @test
+     */
+    public function testProvides(): void
+    {
+        $bust = new BustServiceProvider($this->app);
+        self::assertEquals(['bust'], $bust->provides());
     }
 }


### PR DESCRIPTION
# Description

Improved test coverage from 78% to 92%

# How Has This Been Tested?

- [ ] TestProvides() was added in tests/Integration/BustServiceProviderTest.php

# Checklist:

- [ X] My code follows the style guidelines of this project
- [ X] I have performed a self-review of my own code
- [ X] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [X ] My changes generate no new warnings
- [ X] I have added tests that prove my fix is effective or that my feature works
- [ X] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
